### PR TITLE
Use new URL with `/blog/` on `www.ledger.com`

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
               <span itemprop="name">{{ item.name }}</span>
             </a>
           {% endfor %}
-          <a target="_blank" rel="noreferrer" rel="noopener" class="header__link_out" href="https://www.ledger.com/category/donjon" itemprop="url">
+          <a target="_blank" rel="noreferrer" rel="noopener" class="header__link_out" href="https://www.ledger.com/blog/category/donjon" itemprop="url">
             <span itemprop="name">Blog</span>
             <svg style="margin-left: 8px" width="16" height="16" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
               <path d="m20 20h-16v-15.94l4-0.05952v-4h-8v24h24v-10h-4zm-8-20 4 4-6 6 4 4 6-6 4 4v-12z" stroke-width=".03125"/>


### PR DESCRIPTION
The "Donjon" page on Ledger website is migrating from https://www.ledger.com/category/donjon to https://www.ledger.com/blog/category/donjon.

Update the blog link accordingly.